### PR TITLE
TTY resize request should use POST

### DIFF
--- a/examples/resize.php
+++ b/examples/resize.php
@@ -1,0 +1,26 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use React\EventLoop\Factory as LoopFactory;
+use Clue\React\Docker\Factory;
+
+$container = isset($argv[1]) ? $argv[1] : 'asd';
+
+$loop = LoopFactory::create();
+
+$factory = new Factory($loop);
+$client = $factory->createClient();
+
+$client->containerInspect($container)->then(function ($info) use ($client, $container) {
+    $size = $info['HostConfig']['ConsoleSize'];
+
+    echo 'Current TTY size is ' . $size[0] . 'x' . $size[1] . PHP_EOL;
+
+    return $client->containerResize($container, $size[0] + 10, $size[1] + 10);
+})->then(function () use ($client) {
+    echo 'Successfully set' . PHP_EOL;
+}, 'printf');
+
+
+$loop->run();

--- a/src/Client.php
+++ b/src/Client.php
@@ -275,7 +275,7 @@ class Client
      */
     public function containerResize($container, $w, $h)
     {
-        return $this->browser->get(
+        return $this->browser->post(
             $this->uri->expand(
                 '/containers/{container}/resize{?w,h}',
                 array(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -186,7 +186,7 @@ class ClientTest extends TestCase
 
     public function testContainerResize()
     {
-        $this->expectRequestFlow('get', '/containers/123/resize?w=800&h=600', $this->createResponse(), 'expectEmpty');
+        $this->expectRequestFlow('POST', '/containers/123/resize?w=800&h=600', $this->createResponse(), 'expectEmpty');
 
         $this->expectPromiseResolveWith('', $this->client->containerResize(123, 800, 600));
     }


### PR DESCRIPTION
The v1.15 API documention describes this as a GET request, which always appeared strange. I've tested this against the v1.15 API and can confirm this should have been a POST request ever since. The API documentation has been updated as of v1.16, but does not mention this fix at all.

https://docs.docker.com/engine/reference/api/docker_remote_api_v1.15/#resize-a-container-tty
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.16/#resize-a-container-tty
https://docs.docker.com/engine/reference/api/docker_remote_api/#v1-16-api-changes
https://github.com/docker/docker-py/blob/fdd118706a1e63cc22821e6610cfd861eca1f7b9/docker/api/container.py#L287