### PR TITLE
Fix execResize() to issue POST request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -856,7 +856,7 @@ class Client
      */
     public function execResize($exec, $w, $h)
     {
-        return $this->browser->get(
+        return $this->browser->post(
             $this->uri->expand(
                 '/exec/{exec}/resize{?w,h}',
                 array(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -357,7 +357,7 @@ class ClientTest extends TestCase
 
     public function testExecResize()
     {
-        $this->expectRequestFlow('get', '/exec/123/resize?w=800&h=600', $this->createResponse(), 'expectEmpty');
+        $this->expectRequestFlow('POST', '/exec/123/resize?w=800&h=600', $this->createResponse(), 'expectEmpty');
 
         $this->expectPromiseResolveWith('', $this->client->execResize(123, 800, 600));
     }


### PR DESCRIPTION
Also refs #29. Unlike #29 this has always been documented to be a POST request: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.15/#exec-resize